### PR TITLE
:loud_sound: Adds more logging to the garbage collection process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ check_include_file("stdio.h" HAVE_STDIO)
 check_include_file("unistd.h" HAVE_UNISTD)
 check_include_file("libgen.h" HAVE_LIBGEN)
 check_include_file("windows.h" HAVE_WINDOWS)
+check_include_file("execinfo.h" HAVE_EXECINFO)
 
 check_symbol_exists(arc4random_buf "stdlib.h" HAVE_ARC4RAND)
 

--- a/src/melon/core/function.c
+++ b/src/melon/core/function.c
@@ -30,6 +30,17 @@ TRet melFreeFunction(VM* vm, GCItem* item)
     
 #ifdef _TRACK_ALLOCATIONS_GC
     printf("Freeing function of " MELON_PRINTF_SIZE " bytes (%p), total bytes now = " MELON_PRINTF_SIZE "\n", size + sizeof(GCItem), item, vm->gc.usedBytes - (size + sizeof(GCItem)));
+
+    Function* f = melM_functionFromObj(item);
+
+    if (f->debug.file != NULL) 
+    {
+        printf(
+            "Function was declared at: %s:" MELON_PRINTF_SIZE "\n",
+            f->debug.file,
+            f->debug.count > 0 ? f->debug.lines[0] : 0
+        );
+    }
 #endif
 
     vm->gc.usedBytes -= size;

--- a/src/melon/core/gc.c
+++ b/src/melon/core/gc.c
@@ -34,10 +34,11 @@
 
 #ifdef _DEBUG_GC
 #define melM_gcLog(...) printf("[GC] " __VA_ARGS__); fflush(stdout)
+#define melM_gcLogObj(vm, obj, ...) printf("[GC] " __VA_ARGS__); melPrintGCItemUtils(vm, obj)
 #else
 #define melM_gcLog(...) do { } while(0)
+#define melM_gcLogObj(obj, ...) do { } while(0)
 #endif
-
 #ifdef MELON_GC_STATS_ENABLED
 #define melM_gcStatsUpdate(block) \
     { \
@@ -370,6 +371,8 @@ TRet melRestorePauseGC(VM* vm, GC* gc)
 
 static TRet melProcessGreyStack(VM* vm, GC* gc, TSize unitOfWorkCap)
 {
+    melM_gcLog(" --- Processing grey stack\n");
+
     while(gc->greyStackSize > 0)
     {
         assert(gc->greyStackSize > 0);
@@ -383,12 +386,14 @@ static TRet melProcessGreyStack(VM* vm, GC* gc, TSize unitOfWorkCap)
         }
     }
 
+    melM_gcLog(" ---- Processing grey stack ended\n");
+
     return 0;
 }
 
 static void melSwapColorMarkers(GC* gc)
 {
-    melM_gcLog("Swapping whites and blacks");
+    melM_gcLog("Swapping whites and blacks\n");
 
     TUint8 tmp = gc->whiteMarker;
     gc->whiteMarker = gc->blackMarker;
@@ -405,6 +410,8 @@ static void melSwapColorMarkers(GC* gc)
 
 static void melEndMajorCycle(GC* gc)
 {
+    melM_gcLog(" ------ Major cycle ended\n");
+
     melStatsEndCycle(gc);
     melSwapColorMarkers(gc);
     
@@ -419,33 +426,54 @@ static void melEndMajorCycle(GC* gc)
 static void melMarkRoots(VM* vm, GC* gc)
 {
     RootNodeGC* curRoot = gc->rootsList;
+ 
+    melM_gcLog(" --- Marking roots grey\n");
 
     while (curRoot != NULL)
     {
-        melMarkGreyGC(gc, curRoot->item);
+        melMarkGreyGC(vm, gc, curRoot->item);
         curRoot = curRoot->next;
     }
 
+    melM_gcLog(" --- Roots marked\n");
+    melM_gcLog(" --- Marking stack grey\n");
+
+#ifdef _DEBUG_GC
+    melPrintStackUtils(vm);
+#endif
+
     for (TSize i = 0; i < vm->stack.top; i++)
     {
-        melMarkGreyValueGC(gc, &vm->stack.stack[i]);
+        melMarkGreyValueGC(vm, gc, &vm->stack.stack[i]);
     }
+
+    melM_gcLog(" --- Stack marked\n");
+    melM_gcLog(" --- Marking call stack grey\n");
+
+#ifdef _DEBUG_GC
+    melPrintCallStackUtils(vm);
+#endif
 
     for (TSize i = 0; i < vm->callStack.top; i++)
     {
         CallFrame* cf = melM_stackGet(&vm->callStack, i);
-        melMarkGreyGC(gc, cf->closure);
+        melMarkGreyGC(vm, gc, cf->closure);
     }
+
+    melM_gcLog(" --- Call stack marked\n");
+    melM_gcLog(" --- Marking range iterator pool grey\n");
 
     for (TSize i = 0; i < gc->rangeIteratorPoolCount; i++)
     {
-        melMarkGreyGC(gc, gc->rangeIteratorPool[i]);
+        melMarkGreyGC(vm, gc, gc->rangeIteratorPool[i]);
     }
+
+    melM_gcLog(" --- Range iterator marked\n");
 }
 
 static void melDoMinorCollection(VM* vm, GC* gc)
 {
-    melM_gcLog("Starting minor phase\n");
+    melM_gcLog(" ------- Starting minor phase " MELON_PRINTF_SIZE "\n", gc->globalStats.totalSamples);
 
     melStatsStartCycle(vm, gc);
 
@@ -502,7 +530,7 @@ static void melDoMinorCollection(VM* vm, GC* gc)
         }
 
         melM_gcLog(
-            "Whites count %ld >= %ld: starting major collection\n",
+            " ------- Whites count %ld >= %ld: starting major collection\n",
             gc->whitesCount, 
             gc->nextMajorTriggerSize
         );
@@ -513,7 +541,7 @@ static void melDoMinorCollection(VM* vm, GC* gc)
     else
     {
         melM_gcLog(
-            "Minor collection terminated (whites count = %ld)\n", 
+            " ------- Minor collection terminated (whites count = %ld)\n", 
             gc->whitesCount
         );
 
@@ -533,7 +561,12 @@ static void melDoMarkIteration(VM* vm, GC* gc)
 
     melMarkRoots(vm, gc);
 
-    melM_gcLog("Marking step: grey = " MELON_PRINTF_INT ", white = " MELON_PRINTF_INT "\n", gc->greyStackSize, gc->whitesCount);
+    melM_gcLog(
+        " ------- Marking step " MELON_PRINTF_INT ": grey = " MELON_PRINTF_INT ", white = " MELON_PRINTF_INT "\n",
+        gc->globalStats.totalSamples, 
+        gc->greyStackSize, 
+        gc->whitesCount
+    );
 
     melProcessGreyStack(
         vm, 
@@ -576,7 +609,7 @@ static void melDoSweepIteration(VM* vm, GC* gc)
     GCItem* curItem = gc->whitesList;
     GCItem* prevItem = NULL;
 
-    melM_gcLog("Sweeping " MELON_PRINTF_SIZE " white objects\n", gc->whitesCount);
+    melM_gcLog(" ------- Sweeping " MELON_PRINTF_SIZE " white objects\n", gc->whitesCount);
 
     while (curItem != NULL)
     {
@@ -622,7 +655,12 @@ TRet melTriggerGC(VM* vm, GC* gc)
         return 0;
     }
 
-    melM_gcLog("Triggering GC: allocated %lu bytes\n", gc->usedBytes);
+    melM_gcLog(" ------ Triggering GC: allocated " MELON_PRINTF_SIZE " bytes\n", gc->usedBytes);
+
+#ifdef _DEBUG_GC
+    melPrintVMCurrentLocation(vm);
+    melPrintNativeStackUtils();
+#endif
 
     if (gc->phase == MELON_GC_STOPPED_PHASE)
     {
@@ -705,22 +743,31 @@ TRet melRemoveRootGC(VM* vm, GC* gc, GCItem* item)
     return 1;
 }
 
-TRet melMarkGreyGC(GC* gc, GCItem* item)
+TRet melMarkGreyGC(VM* vm, GC* gc, GCItem* item)
 {
     assert(item->type > MELON_TYPE_NONE && item->type <= MELON_TYPE_MAX_ID);
+
+    melM_gcLog(
+        "Visiting %p for grey %s marking\n",
+        item,
+        gc->phase == MELON_GC_MARK_PHASE ? "major" : "minor"
+    );
 
     // Don't follow young -> old references in minor collections
     if (gc->phase == MELON_GC_MINOR_PHASE && melM_isOldGCItem(gc, item))
     {
+        melM_gcLog("Skipping %p grey marking, old item and minor collection.\n", item);
         return 0;
     }
 
     if (melM_isDarkGCItem(gc, item))
     {
+        melM_gcLog("Skipping %p grey marking, item is already dark.\n", item);
         return 0;
     }
 
-    melM_gcLog(
+    melM_gcLogObj(
+        vm, item,
         "Marking %s grey: %p\n", 
         gc->phase == MELON_GC_MARK_PHASE ? "major" : "minor", 
         item
@@ -754,7 +801,7 @@ static TRet melVisitMarkGreyGC(VM* vm, void* vgc, GCItem* item, TSize depth)
     assert(vgc != NULL);
     GC* gc = (GC*)vgc;
 
-    melMarkGreyGC(gc, item);
+    melMarkGreyGC(vm, gc, item);
 
     return depth;
 }
@@ -765,6 +812,19 @@ TRet melMarkBlackGC(VM* vm, GC* gc, GCItem* item)
     {
         return 1;
     }
+
+    melM_gcLog("melMarkBlackGC(%p)\n", item);
+
+#ifdef _TRACK_ALLOCATIONS_GC
+    if (item == vm->global)
+    {
+        melM_gcLog("Marking Global object black\n");
+    }
+    else
+    {
+        melPrintGCItemUtils(vm, item);
+    }
+#endif
 
     melM_gcStatsUpdate({
         stat->scanned++;
@@ -787,7 +847,7 @@ TRet melMarkBlackGC(VM* vm, GC* gc, GCItem* item)
     return 0;
 }
 
-TRet melMarkGreyValueGC(GC* gc, Value* item)
+TRet melMarkGreyValueGC(VM* vm, GC* gc, Value* item)
 {    
     assert(item != NULL);
     assert(item->type > MELON_TYPE_NONE && item->type <= MELON_TYPE_MAX_ID);
@@ -797,7 +857,7 @@ TRet melMarkGreyValueGC(GC* gc, Value* item)
         return 0;
     }
 
-    return melMarkGreyGC(gc, item->pack.obj);
+    return melMarkGreyGC(vm, gc, item->pack.obj);
 }
 
 TRet melMarkBlackValueGC(VM* vm, GC* gc, Value* item)
@@ -1017,7 +1077,7 @@ TRet melWriteBarrierGC(VM* vm, GCItem* obj, GCItem* value)
 {
     if (melM_gcIsRunning(&vm->gc) && melM_isBlackGCItem(&vm->gc, obj))
     {
-        melMarkGreyGC(&vm->gc, value);
+        melMarkGreyGC(vm, &vm->gc, value);
     }
     else if (
         !melM_gcIsMajorCollecting(&vm->gc)

--- a/src/melon/core/gc.h
+++ b/src/melon/core/gc.h
@@ -138,8 +138,8 @@ TRet melAddRootGC(VM* vm, GC* gc, GCItem* item);
 TRet melAddRootValueGC(VM* vm, GC* gc, Value* value);
 TRet melRemoveRootGC(VM* vm, GC* gc, GCItem* item);
 
-TRet melMarkGreyGC(GC* gc, GCItem* item);
-TRet melMarkGreyValueGC(GC* gc, Value* item);
+TRet melMarkGreyGC(VM* vm, GC* gc, GCItem* item);
+TRet melMarkGreyValueGC(VM* vm, GC* gc, Value* item);
 
 TRet melAddWhiteGC(GC* gc, GCItem* item);
 TRet melRemoveWhiteGC(GC* gc, GCItem* item);

--- a/src/melon/core/utils.h
+++ b/src/melon/core/utils.h
@@ -38,6 +38,8 @@ void melPrintUpvaluesUtils(VM* vm);
 struct StrFormat melDumpGCInfoUtils(VM* vm, TBool includeSize);
 void melPrintGCInfoUtils(VM* vm, TBool includeSize);
 
+void melPrintNativeStackUtils();
+
 TRet melExtractSourceFragmentUtils(
     struct StrFormat* sf, 
     const char* source, 
@@ -60,6 +62,9 @@ void melPrintErrorAtSourceUtils(
     TSize len,
     TSize ctxLen
 );
+
+struct StrFormat melDumpVMCurrentLocation(VM* vm);
+void melPrintVMCurrentLocation(VM* vm);
 
 void melVMPrintFunctionUtils(struct StrFormat* sf, void* ctx);
 

--- a/src/melon/modules/debug/debug_module.c
+++ b/src/melon/modules/debug/debug_module.c
@@ -50,12 +50,21 @@ static TByte getCallstackFunc(VM* vm)
     return 1;
 }
 
+static TByte dumpFunc(VM* vm)
+{
+    melM_arg(vm, val, MELON_TYPE_NONE, 0);
+    melPrintValueUtils(vm, val);
+    
+    return 0;
+}
+
 static const ModuleFunction funcs[] = {
     // name, args, locals, func
     { "printStack", 0, 0, &printStackFunc},
     { "printCallstack", 0, 0, &printCallstackFunc},
     { "error", 1, 0, &errorFunc},
     { "getCallstack", 0, 0, &getCallstackFunc},
+    { "dump", 1, 0, &dumpFunc },
     NULL
 };
 

--- a/src/melon/modules/modules.c
+++ b/src/melon/modules/modules.c
@@ -245,6 +245,10 @@ TRet melRegisterModule(VM* vm, const char* name, ModuleInitFunc initFunc)
     StackEntry* obj = melM_stackOffset(&vm->stack, 0);
     assert(obj->type == MELON_TYPE_OBJECT);
 
+#ifdef _DEBUG_GC
+    printf("[Modules] Module registered '%s': %p\n", name, obj->pack.obj);
+#endif
+
     GCItem* nameString = melNewString(vm, name, strlen(name));
     melM_vstackPushGCItem(&vm->stack, nameString); // Avoid GCing
 

--- a/tests/fixtures/vm/bytecode/32/basic-upvalues.out
+++ b/tests/fixtures/vm/bytecode/32/basic-upvalues.out
@@ -1,1 +1,1 @@
-GC Allocated Objs: 426
+GC Allocated Objs: 429

--- a/tests/fixtures/vm/bytecode/32/gc-objects.out
+++ b/tests/fixtures/vm/bytecode/32/gc-objects.out
@@ -1,1 +1,1 @@
-GC Allocated Objs: 512
+GC Allocated Objs: 515

--- a/tests/fixtures/vm/bytecode/64/basic-upvalues.out
+++ b/tests/fixtures/vm/bytecode/64/basic-upvalues.out
@@ -1,1 +1,1 @@
-GC Allocated Objs: 426
+GC Allocated Objs: 429

--- a/tests/fixtures/vm/bytecode/64/gc-objects.out
+++ b/tests/fixtures/vm/bytecode/64/gc-objects.out
@@ -1,1 +1,1 @@
-GC Allocated Objs: 512
+GC Allocated Objs: 515


### PR DESCRIPTION
… order to debug potential issues.

- :sparkles: Adds a 'dump' function to the 'debug' module that exposes the internal melDumpValue.
- :sparkels: Adds some utility function, for example melPrintNativeStackUtils that prints the current native callstack on Posix.
- :white_check_mark: Updates unit tests